### PR TITLE
Use groovy call sites to call back into the Observable methods.

### DIFF
--- a/src/perf/java/rx/jmh/InputWithIncrementingInteger.java
+++ b/src/perf/java/rx/jmh/InputWithIncrementingInteger.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.jmh;
+
+import java.util.Iterator;
+
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import rx.Observable;
+import rx.Observable.OnSubscribe;
+import rx.Observer;
+import rx.Subscriber;
+
+/**
+ * Exposes an Observable and Observer that increments n Integers and consumes them in a Blackhole.
+ */
+public abstract class InputWithIncrementingInteger {
+    public Iterable<Integer> iterable;
+    public Observable<Integer> observable;
+    public Observable<Integer> firehose;
+    public Blackhole bh;
+    public Observer<Integer> observer;
+
+    public abstract int getSize();
+
+    @Setup
+    public void setup(final Blackhole bh) {
+        this.bh = bh;
+        observable = Observable.range(0, getSize());
+
+        firehose = Observable.create(new OnSubscribe<Integer>() {
+
+            @Override
+            public void call(Subscriber<? super Integer> s) {
+                for (int i = 0; i < getSize(); i++) {
+                    s.onNext(i);
+                }
+                s.onCompleted();
+            }
+
+        });
+
+        iterable = new Iterable<Integer>() {
+
+            @Override
+            public Iterator<Integer> iterator() {
+                return new Iterator<Integer>() {
+
+                    int i = 0;
+
+                    @Override
+                    public boolean hasNext() {
+                        return i < getSize();
+                    }
+
+                    @Override
+                    public Integer next() {
+                        return i++;
+                    }
+
+                    @Override
+                    public void remove() {
+
+                    }
+
+                };
+            }
+
+        };
+        observer = new Observer<Integer>() {
+
+            @Override
+            public void onCompleted() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onNext(Integer t) {
+                bh.consume(t);
+            }
+
+        };
+
+    }
+
+    public LatchedObserver<Integer> newLatchedObserver() {
+        return new LatchedObserver<Integer>(bh);
+    }
+
+    public Subscriber<Integer> newSubscriber() {
+        return new Subscriber<Integer>() {
+
+            @Override
+            public void onCompleted() {
+
+            }
+
+            @Override
+            public void onError(Throwable e) {
+
+            }
+
+            @Override
+            public void onNext(Integer t) {
+                bh.consume(t);
+            }
+
+        };
+    }
+
+}

--- a/src/perf/java/rx/jmh/LatchedObserver.java
+++ b/src/perf/java/rx/jmh/LatchedObserver.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.jmh;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.openjdk.jmh.infra.Blackhole;
+
+import rx.Observer;
+
+public class LatchedObserver<T> implements Observer<T> {
+
+    public CountDownLatch latch = new CountDownLatch(1);
+    private final Blackhole bh;
+
+    public LatchedObserver(Blackhole bh) {
+        this.bh = bh;
+    }
+
+    @Override
+    public void onCompleted() {
+        latch.countDown();
+    }
+
+    @Override
+    public void onError(Throwable e) {
+        latch.countDown();
+    }
+
+    @Override
+    public void onNext(T t) {
+        bh.consume(t);
+    }
+
+}

--- a/src/perf/java/rx/jmh/README.txt
+++ b/src/perf/java/rx/jmh/README.txt
@@ -1,0 +1,6 @@
+For examples see:
+
+http://hg.openjdk.java.net/code-tools/jmh/file/tip/jmh-samples/src/main/java/org/openjdk/jmh/samples/
+https://github.com/nitsanw/jmh-samples/blob/master/src/main/java/org/openjdk/jmh/samples/
+https://github.com/nitsanw/jmh-samples/blob/master/src/main/java/org/openjdk/jmh/samples/JMHSample_15_Asymmetric.java
+https://github.com/nitsanw/jmh-samples/blob/master/src/main/java/org/openjdk/jmh/samples/JMHSample_09_Blackholes.java#L86

--- a/src/perf/java/rx/lang/groovy/ExtensionPerf.java
+++ b/src/perf/java/rx/lang/groovy/ExtensionPerf.java
@@ -1,0 +1,51 @@
+package rx.lang.groovy;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import rx.Observable;
+import rx.jmh.InputWithIncrementingInteger;
+import groovy.lang.GroovyShell;
+import groovy.lang.Script;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class ExtensionPerf {
+    @State(Scope.Thread)
+    public static class Input extends InputWithIncrementingInteger {
+        public GroovyShell shell;
+        public Script script;
+
+        @Param({ "1", "1000", "1000000" })
+        public int size;
+
+        @Param({ "in.map({ it + 1})", "in.filter({ it != 0 })" })
+        public String source;
+
+        @Override
+        public int getSize() {
+            return size;
+        }
+
+        @Setup
+        public void initGroovyStuff() {
+            shell = new GroovyShell();
+            script = shell.parse(source);
+            shell.setVariable("in", firehose);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Benchmark
+    public void extension(Input input) throws InterruptedException {
+        ((Observable<Integer>) input.script.run()).subscribe(input.observer);
+    }
+}

--- a/src/perf/java/rx/lang/groovy/ObservableExtension.java
+++ b/src/perf/java/rx/lang/groovy/ObservableExtension.java
@@ -1,0 +1,10 @@
+package rx.lang.groovy;
+
+import rx.Observable;
+import rx.functions.Func1;
+
+public class ObservableExtension {
+    public <T> Observable<T> filter(Observable<T> self, Func1<? super T, Boolean> predicate) {
+        return self.filter(predicate);
+    }
+}

--- a/src/perf/java/rx/lang/groovy/README.md
+++ b/src/perf/java/rx/lang/groovy/README.md
@@ -1,0 +1,46 @@
+# JMH Benchmarks
+
+### Run All
+
+```
+./gradlew benchmarks
+```
+
+### Run Specific Class
+
+```
+./gradlew benchmarks '-Pjmh=.*OperatorMapPerf.*'
+```
+
+### Arguments
+
+Optionally pass arguments for custom execution. Example:
+
+```
+./gradlew benchmarks '-Pjmh=-f 1 -tu s -bm thrpt -wi 5 -i 5 -r 1 .*OperatorMapPerf.*'
+```
+
+gives output like this:
+
+```
+# Warmup Iteration   1: 17541564.529 ops/s
+# Warmup Iteration   2: 20923290.222 ops/s
+# Warmup Iteration   3: 20743426.176 ops/s
+# Warmup Iteration   4: 23462116.103 ops/s
+# Warmup Iteration   5: 24283139.706 ops/s
+Iteration   1: 23317338.378 ops/s
+Iteration   2: 23478480.189 ops/s
+Iteration   3: 23186077.043 ops/s
+Iteration   4: 22120569.854 ops/s
+Iteration   5: 21581828.652 ops/s
+
+Result: 22736858.823 ±(99.9%) 3223211.259 ops/s [Average]
+  Statistics: (min, avg, max) = (21581828.652, 22736858.823, 23478480.189), stdev = 837057.728
+  Confidence interval (99.9%): [19513647.564, 25960070.082]
+```
+
+To see all options:
+
+```
+./gradlew benchmarks '-Pjmh=-h'
+```

--- a/src/perf/resources/META-INF/services/org.codehaus.groovy.runtime.ExtensionModule
+++ b/src/perf/resources/META-INF/services/org.codehaus.groovy.runtime.ExtensionModule
@@ -1,0 +1,3 @@
+moduleName=groovy-extensions-perf
+moduleVersion=1.0
+extensionClasses=rx.lang.groovy.ObservableExtension


### PR DESCRIPTION
Methods on `rx.Observable` that have an argument that take a `rx.function.Function` can't be extended with groovy extensions.

The RxGroovy extension adds new `groovy.lang.Closure` version of each method on `rx.Observable` that has `rx.function.Function` as an argument.  When the closure version is invoked it wraps the closure in a function and invokes the `java.lang.reflect.Method` directly bypassing any attempt to extend the original.

This PR changes the invoke to use groovy's internal method resolution and caching.  This allows additional groovy extensions to be applied.  If no extension are present it will use custom generated bytecode to avoid doing reflection.

```
################## BEFORE

# Run complete. Total time: 00:03:17

Benchmark                        (size)               (source)   Mode   Samples        Score  Score error    Units
r.l.g.ExtensionPerf.extension         1      in.map({ it + 1})  thrpt         5  3212878.269    29678.977    ops/s
r.l.g.ExtensionPerf.extension         1 in.filter({ it != 0 })  thrpt         5  3497772.417   534053.736    ops/s
r.l.g.ExtensionPerf.extension      1000      in.map({ it + 1})  thrpt         5    18137.493      432.222    ops/s
r.l.g.ExtensionPerf.extension      1000 in.filter({ it != 0 })  thrpt         5    19746.618      886.572    ops/s
r.l.g.ExtensionPerf.extension   1000000      in.map({ it + 1})  thrpt         5       18.842        0.346    ops/s
r.l.g.ExtensionPerf.extension   1000000 in.filter({ it != 0 })  thrpt         5       19.297        0.673    ops/s


################## AFTER

# Run complete. Total time: 00:03:17

Benchmark                        (size)               (source)   Mode   Samples        Score  Score error    Units
r.l.g.ExtensionPerf.extension         1      in.map({ it + 1})  thrpt         5  4036047.884   117545.855    ops/s
r.l.g.ExtensionPerf.extension         1 in.filter({ it != 0 })  thrpt         5  4161935.126   131375.955    ops/s
r.l.g.ExtensionPerf.extension      1000      in.map({ it + 1})  thrpt         5    19015.365     1228.843    ops/s
r.l.g.ExtensionPerf.extension      1000 in.filter({ it != 0 })  thrpt         5    19754.786      263.644    ops/s
r.l.g.ExtensionPerf.extension   1000000      in.map({ it + 1})  thrpt         5       17.685        6.204    ops/s
r.l.g.ExtensionPerf.extension   1000000 in.filter({ it != 0 })  thrpt         5       18.208        3.433    ops/s
```
